### PR TITLE
[SOLVED] add -l argument for printing list of repositories #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ usage: getgit [-h] [-s SERVICE] [-n NICKNAME] [-r REP_NAME] [-p PORT]
 
 options:
   -h, --help            show this help message and exit
+  -l, --list             list all cloned repositories
   -s SERVICE, --service SERVICE
   -n NICKNAME, --nickname NICKNAME
   -r REP_NAME, --rep-name REP_NAME

--- a/getgit/args.py
+++ b/getgit/args.py
@@ -4,6 +4,7 @@ from .constants import PROG_NAME
 
 def parse_args():
     args = ArgumentParser(prog=PROG_NAME)
+    args.add_argument('-l', '--list', action='store_true')
     args.add_argument('-s', '--service', type=str)
     args.add_argument('-n', '--nickname', type=str)
     args.add_argument('-r', '--rep-name', type=str)

--- a/getgit/cli.py
+++ b/getgit/cli.py
@@ -6,7 +6,7 @@ if platform == 'linux':
     from simple_term_menu import TerminalMenu
 
 from .clone import clone_rep
-from .config import USER_CONFIG_DIR, USER_CONFIG_NAME
+from .config import USER_CONFIG_DIR, USER_CONFIG_NAME, BASE_DIR
 from .parse import get_parse_config_data, parse_reps, get_url
 from .wwyaml import UserData, check_filling_of_data, load_data, put_data
 
@@ -25,6 +25,14 @@ def print_cfg_info():
     print(f'Config info in {abs_path}\n')
     print(file.read_text())
 
+def print_repositories_list():
+    file = BASE_DIR / ".repos"
+    abs_path = str(file.absolute())
+    if not file.exists():
+        print(f'Repositories list file does not exist in {abs_path}')
+        return
+    print("Cloned repositories (user/repo-name):")
+    print(file.read_text())
 
 def dl_rep(rep_name: str):
     user_data = load_data()

--- a/getgit/cli.py
+++ b/getgit/cli.py
@@ -6,7 +6,7 @@ if platform == 'linux':
     from simple_term_menu import TerminalMenu
 
 from .clone import clone_rep
-from .config import USER_CONFIG_DIR, USER_CONFIG_NAME, BASE_DIR
+from .config import USER_CONFIG_DIR, USER_CONFIG_NAME, REPOS_TEXT_FILE
 from .parse import get_parse_config_data, parse_reps, get_url
 from .wwyaml import UserData, check_filling_of_data, load_data, put_data
 
@@ -26,7 +26,7 @@ def print_cfg_info():
     print(file.read_text())
 
 def print_repositories_list():
-    file = BASE_DIR / ".repos"
+    file = USER_CONFIG_DIR / REPOS_TEXT_FILE
     abs_path = str(file.absolute())
     if not file.exists():
         print(f'Repositories list file does not exist in {abs_path}')

--- a/getgit/clone.py
+++ b/getgit/clone.py
@@ -1,6 +1,7 @@
 from os import system
 from .parse import get_parse_config_data
-from .wwyaml import UserData
+from .wwyaml import UserData, create_file
+from .config import BASE_DIR
 
 
 def clone_rep(data: UserData, rep_name: str):
@@ -10,3 +11,7 @@ def clone_rep(data: UserData, rep_name: str):
     message = message.replace('rep_name', rep_name)
     print(message)
     system(f'git clone {message}')
+    file = BASE_DIR / ".repos"
+    if not file.exists():
+        create_file(BASE_DIR, ".repos")
+    file.write_text(f"{data.nickname}/{rep_name}")

--- a/getgit/clone.py
+++ b/getgit/clone.py
@@ -1,7 +1,7 @@
 from os import system
 from .parse import get_parse_config_data
 from .wwyaml import UserData, create_file
-from .config import BASE_DIR
+from .config import USER_CONFIG_DIR, REPOS_TEXT_FILE
 
 
 def clone_rep(data: UserData, rep_name: str):
@@ -11,7 +11,7 @@ def clone_rep(data: UserData, rep_name: str):
     message = message.replace('rep_name', rep_name)
     print(message)
     system(f'git clone {message}')
-    file = BASE_DIR / ".repos"
+    file = USER_CONFIG_DIR / REPOS_TEXT_FILE
     if not file.exists():
-        create_file(BASE_DIR, ".repos")
+        create_file(USER_CONFIG_DIR, REPOS_TEXT_FILE)
     file.write_text(f"{data.nickname}/{rep_name}")

--- a/getgit/config.py
+++ b/getgit/config.py
@@ -7,3 +7,5 @@ PROG_VERS = '0.1.6'
 USER_CONFIG_DIR = Path.home() / '.config/getgit'
 USER_CONFIG_NAME = 'config.yaml'
 PARSE_CONFIG_PATH = Path(__file__).parent / 'config/parse.yaml'
+
+BASE_DIR = Path.home()

--- a/getgit/config.py
+++ b/getgit/config.py
@@ -8,4 +8,4 @@ USER_CONFIG_DIR = Path.home() / '.config/getgit'
 USER_CONFIG_NAME = 'config.yaml'
 PARSE_CONFIG_PATH = Path(__file__).parent / 'config/parse.yaml'
 
-BASE_DIR = Path.home()
+REPOS_TEXT_FILE = '.repos'

--- a/getgit/main.py
+++ b/getgit/main.py
@@ -1,4 +1,4 @@
-from .cli import cli, print_cfg_info
+from .cli import cli, print_cfg_info, print_repositories_list
 from .args import parse_args
 from .clone import clone_rep
 from .wwyaml import UserData, load_dict_to_UserData, change_UserData, put_data, load_data
@@ -18,5 +18,7 @@ def main():
         clone_rep(user_data, args.rep_name)
     elif args.cfg_info:
         print_cfg_info()
+    elif args.list:
+        print_repositories_list()
     else:
         cli()


### PR DESCRIPTION
Added flag **-l** or **--list** to getgit.

It stores the cloned repositories on the text file located in _$PATH/.config/getgit/.repos_ in the way "<repo-owner>/<repo-name>".

